### PR TITLE
Include source-map-support dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dynamoose": "^0.6.0",
     "elasticsearch": "^11.0.1",
     "lodash": "^4.14.2",
+    "source-map-support": "^0.4.6",
     "splunk-sdk": "^1.8.0",
     "steed": "^1.1.3"
   },


### PR DESCRIPTION
Coming from a fresh install, `npm run prepublish` failed without this. @scisco does it need to be included?