### PR TITLE
Create build directory if none exists

### DIFF
--- a/lib/aws/lambda.js
+++ b/lib/aws/lambda.js
@@ -86,6 +86,9 @@ function updateLambda(options, name, webpack) {
     exec('webpack');
   }
 
+  // create the lambda folder if it doesn't already exist
+  fs.mkdirpSync('build/lambda');
+
   // Update the zip file
   exec(`cd dist && zip -r ../build/lambda/${name} ${name}`);
 


### PR DESCRIPTION
Lets you run `updateLambda` even if you haven't run `uploadLambda` locally before.