### PR TITLE
CUMULUS-1018 Fix Repo Vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "budo": "^10.0.0",
     "cz-conventional-changelog": "2.0.0",
     "expect": "^21.0.2",
-    "mocha": "^3.2.0",
     "to-vfile": "^2.0.0",
     "uglify-js": "^3.0.27"
   }


### PR DESCRIPTION
Mocha was too old and had vulnerabilities. I don't see it used anywhere in the repo so I just removed it.