### PR TITLE
Adds distributionMetrics endpoint documentation

### DIFF
--- a/content/distribution-metrics.md
+++ b/content/distribution-metrics.md
@@ -1,0 +1,43 @@
+## Distribution Metrics
+
+The Cumulus API provides information about recent distributionApi performance.
+
+`GET` requests to the `distributionMetrics` endpoint return a json object with the `distributionApi`'s previous 24 hour total number of errors and successes.
+
+Total errors are computed based on the sum of server errors (5XX Errors), user errors (4XX Errors) from the `distributionApi`, as well as any s3 server log metrics that have been published to cloudwatch's custom metric service with parameters:
+
+```
+Metric Name: FailureCount,
+Custom Namespace: CumulusDistribution
+Dimension: Stack  // with Value: prefix
+```
+
+Total successes are computed strictly from the cloudwatch custom metric service with following parameters:
+
+```
+Metric Name: SuccessCount,
+Custom Namespace: CumulusDistribution,
+Dimension: Stack // with Value: prefix
+```
+
+
+The standard and suggested way to publish custom metrics is to deploy [`@cumulus/s3-access-metrics` ](https://github.com/nasa/cumulus/tree/master/packages/s3-access-metrics) and configure it to read the server access logs for your cumulus instance.
+
+
+
+```endpoint
+GET /distributionMetrics
+```
+
+#### Example Request
+```curl
+$ curl https://example.com/distributionMetrics --header 'Authorization: Bearer ReplaceWithTheToken'
+```
+
+#### Example Response
+```json
+{
+  "errors": "5",
+  "successes": "2330"
+}
+```

--- a/content/distribution-metrics.md
+++ b/content/distribution-metrics.md
@@ -1,6 +1,6 @@
 ## Distribution Metrics
 
-The Cumulus API provides information about recent distributionApi performance.
+The Cumulus API provides information about recent distribution API performance.
 
 `GET` requests to the `distributionMetrics` endpoint return a json object with the `distributionApi`'s previous 24 hour total number of errors and successes.
 

--- a/content/distribution-metrics.md
+++ b/content/distribution-metrics.md
@@ -21,7 +21,7 @@ Dimension: Stack // with Value: prefix
 ```
 
 
-The standard and suggested way to publish custom metrics is use the [`@cumulus/s3-access-metrics`](https://github.com/nasa/cumulus/tree/master/packages/s3-access-metrics) package.  It is a independently deployed stack that you must configure to read the server access logs for your cumulus instance.
+The standard and suggested way to publish custom metrics is to use the [`@cumulus/s3-access-metrics`](https://github.com/nasa/cumulus/tree/master/packages/s3-access-metrics) package.  It is a independently deployed stack that you must configure to read the server access logs for your cumulus instance.
 
 
 

--- a/content/distribution-metrics.md
+++ b/content/distribution-metrics.md
@@ -21,7 +21,7 @@ Dimension: Stack // with Value: prefix
 ```
 
 
-The standard and suggested way to publish custom metrics is to deploy [`@cumulus/s3-access-metrics` ](https://github.com/nasa/cumulus/tree/master/packages/s3-access-metrics) and configure it to read the server access logs for your cumulus instance.
+The standard and suggested way to publish custom metrics is use the [`@cumulus/s3-access-metrics`](https://github.com/nasa/cumulus/tree/master/packages/s3-access-metrics) package.  It is a independently deployed stack that you must configure to read the server access logs for your cumulus instance.
 
 
 

--- a/template/src/custom/content.js
+++ b/template/src/custom/content.js
@@ -50,13 +50,16 @@ module.exports =
   fs.readFileSync('./content/schemas.md', 'utf8') + '\n' +
 
   '# Reconciliation Reports\n' +
-  fs.readFileSync('./content/reconciliation-reports.md', 'utf8') + '\n' +
+  fs.readFileSync('./content/reconciliation-reports.md', 'utf8') +  '\n' +
+
+  '# Distribution Metrics\n' +
+  fs.readFileSync('./content/distribution-metrics.md') + '\n' +
 
   '# Instance Metadata\n' +
   fs.readFileSync('./content/instance-meta.md') + '\n' +
 
   '# Elasticsearch\n' +
-  fs.readFileSync('./content/elasticsearch.md') + '\n'
+  fs.readFileSync('./content/elasticsearch.md') + '\n' +
 
   '# Dashboard\n' +
   fs.readFileSync('./content/dashboard.md') + '\n'


### PR DESCRIPTION
[partially solves CUMULUS-779 As a DAAC operator, I want to see a summary of recent distribution errors on the dashboard so I may notice when users are having problems accessing the data](https://github.com/nasa/cumulus/pull/1018/files)