### PR TITLE
CUMULUS-1308 Handle delete of fields via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_Store
 .swo
 package-lock.json
+.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Copyright © 2017 United States Government as represented by the Administrator o
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICE NSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/content/collections.md
+++ b/content/collections.md
@@ -233,14 +233,21 @@ $ curl --request POST https://example.com/collections --header 'Authorization: B
                 "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
             }
         ],
-        "createdAt": 1491946535919,
+        "createdAt": 1491946535919
     }
 }
 ```
 
-## Update collection
+## Update/replace collection
 
-Update values for a collection. Can accept the whole collection object, or just a subset of fields with updated values. For a field reference see the ["Create collection"](#create-collection) section.
+Update/replace an existing collection. Expects payload to specify the entire
+collection object, and will completely replace the existing collection with the
+specified payload. For a field reference see
+["Create collection"](#create-collection).
+
+Returns status 200 on successful replacement, 400 if the `name` or `version`
+property in the payload does not match the corresponding value in the resource
+URI, or 404 if there is no collection with the specified name and version.
 
 ```endpoint
 PUT /collections/{name}/{version}
@@ -249,38 +256,54 @@ PUT /collections/{name}/{version}
 #### Example request
 
 ```curl
-$ curl --request PUT https://example.com/collections/MY_COLLECTION/1 --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json' --data '{
-	"duplicateHandling": "error",
-    "provider_path": "new-path/test-data"
-    "newNeededField": "myCustomFieldValue"
+$ curl --request PUT https://example.com/collections/MOD09GQ/006 --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json' --data '{
+  "name": "MOD09GQ",
+  "version": "006",
+  "dataType": "MOD09GQ",
+  "duplicateHandling": "error",
+  "newNeededField": "myCustomFieldValue",
+  "process": "modis",
+  "provider_path": "new_path/test-data",
+  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
+  "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
+  "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+  "files": [
+    {
+      "bucket": "protected",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
+      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+      "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
+    }
+  ]
 }'
 ```
 
-#### Example response
+#### Example successful response
 
 ```json
 {
-    "name": "MOD09GQ",
-    "version": "006",
-    "dataType": "MOD09GQ",
-    "duplicateHandling": "error",
-    "newNeededField": "myCustomFieldValue",
-    "process": "modis",
-    "provider_path": "new_path/test-data",
-    "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
-    "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
-    "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}",
-    "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-    "files": [
-        {
-            "bucket": "protected",
-            "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
-            "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-            "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
-        }
-    ],
-    "createdAt": 1491946535919,
-    "updatedAt": 1514304825894
+  "name": "MOD09GQ",
+  "version": "006",
+  "dataType": "MOD09GQ",
+  "duplicateHandling": "error",
+  "newNeededField": "myCustomFieldValue",
+  "process": "modis",
+  "provider_path": "new_path/test-data",
+  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
+  "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
+  "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+  "files": [
+    {
+      "bucket": "protected",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
+      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+      "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
+    }
+  ],
+  "createdAt": 1491946535919,
+  "updatedAt": 1514304825894
 }
 ```
 

--- a/content/providers.md
+++ b/content/providers.md
@@ -112,33 +112,43 @@ $ curl --request POST https://example.com/providers --header 'Authorization: Bea
 }
 ```
 
-## Update provider
+## Update/replace provider
 
-Update values for a provider. Can accept the whole provider object, or just a subset of fields, the ones that are being updated.
+Update/replace an existing provider. Expects payload to specify the entire
+provider object, and will completely replace the existing provider with the
+specified payload. For a field reference see
+["Create provider"](#create-provider).
+
+Returns status 200 on successful replacement, 400 if the `id` property in the
+payload does not match the corresponding value in the resource URI, or 404 if
+there is no provider with the specified ID.
 
 ```endpoint
-PUT /providers
+PUT /providers/{id}
 ```
 
 #### Example request
 
 ```curl
 $ curl --request PUT https://example.com/providers/MY_DAAC_SATELLITE --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json' --data '{
-    "host": "https://www.example.co.uk"
+  "id": "MY_DAAC_SATELLITE",
+  "host": "https://www.example.co.uk",
+  "globalConnectionLimit": 10,
+  "protocol": "http"
 }'
 ```
 
-#### Example response
+#### Example successful response
 
 ```json
 {
-    "createdAt": 1491941727851,
-    "id": "MY_DAAC_SATELLITE",
-    "host": "https://www.example.co.uk",
-    "globalConnectionLimit": 10,
-    "updatedAt": 1513956150733,
-    "protocol": "http",
-    "timestamp": 1513956555713
+  "createdAt": 1491941727851,
+  "id": "MY_DAAC_SATELLITE",
+  "host": "https://www.example.co.uk",
+  "globalConnectionLimit": 10,
+  "updatedAt": 1513956150733,
+  "protocol": "http",
+  "timestamp": 1513956555713
 }
 ```
 

--- a/content/rules.md
+++ b/content/rules.md
@@ -150,9 +150,15 @@ $ curl --request POST https://example.com/rules --header 'Authorization: Bearer 
 }
 ```
 
-## Update rule
+## Update/replace rule
 
-Update rules for a collection. Can accept the whole rule object, or just a subset of fields, the ones that are being updated. Returns a mapping of the updated properties. For a field reference see the ["Create rule"](#create-rule) section.
+Update/replace an existing rule. Expects payload to specify the entire
+rule object, and will completely replace the existing rule with the
+specified payload. For a field reference see ["Create rule"](#create-rule).
+
+Returns status 200 on successful replacement, 400 if the `name` property in the
+payload does not match the corresponding value in the resource URI, or 404 if
+there is no rule with the specified name.
 
 Special case:
 
@@ -167,27 +173,40 @@ PUT /rules/{name}
 #### Example request
 
 ```curl
-$ curl --request PUT https://example.com/rules/repeat_test --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json' --data '{"state": "ENABLED"}'
+$ curl --request PUT https://example.com/rules/repeat_test --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json' --data '{
+  "name": "repeat_test",
+  "workflow": "DiscoverPdrs",
+  "collection": {
+    "name": "AST_L1A",
+    "version": "003"
+  },
+  "provider": "local",
+  "rule": {
+    "type": "scheduled",
+    "value": "rate(5 minutes)"
+  },
+  "state": "ENABLED"
+}'
 ```
 
-#### Example response
+#### Example successful response
 
 ```json
 {
-    "workflow": "DiscoverPdrs",
-    "collection": {
-        "name": "AST_L1A",
-        "version": "003"
-    },
-    "updatedAt": 1521755265130,
-    "createdAt": 1510903518741,
-    "provider": "local",
-    "name": "repeat_test",
-    "rule": {
-        "type": "scheduled",
-        "value": "rate(5 minutes)"
-    },
-    "state": "ENABLED"
+  "name": "repeat_test",
+  "workflow": "DiscoverPdrs",
+  "collection": {
+    "name": "AST_L1A",
+    "version": "003"
+  },
+  "updatedAt": 1521755265130,
+  "createdAt": 1510903518741,
+  "provider": "local",
+  "rule": {
+    "type": "scheduled",
+    "value": "rate(5 minutes)"
+  },
+  "state": "ENABLED"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/nasa/cumulus-api.git"
   },
   "author": "Development Seed",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/nasa/cumulus-api/issues"
   },


### PR DESCRIPTION
Updated docs to be in sync with recent API changes for collections, providers, and rules, in which PUTs now perform replacements rather than modifications, and thus expect payloads to contain complete objects rather than partial objects.

I've merged branch CUMULUS-1200 into the branch for this PR to incorporate the changes that @laurenfrederick made since there were merge conflicts to resolve.