### PR TITLE
Update reingest with new parameters.

### DIFF
--- a/content/granules.md
+++ b/content/granules.md
@@ -485,6 +485,7 @@ Overview of the request fields:
 | `ids` | `yes` - if `query` not present | `Array<string>` | List of IDs to process. Required if there is no Elasticsearch query provided |
 | `query` | `yes` - if `ids` not present | `Object` | Query to Elasticsearch to determine which Granules to be reingested. Required if no IDs are given. |
 | `index` | `yes` - if `query` is present | `string` | Elasticsearch index to search with the given query |
+| `workflowName` | `no` | `string` | optional workflow name that allows different workflow and initial input to be used during reingest. See below.  |
 
 
 An optional data parameter of `workflowName` is also available to allow you to override the input message to the reingest. If `workflowName` is specified, the original message is pulled directly

--- a/content/granules.md
+++ b/content/granules.md
@@ -468,7 +468,7 @@ curl -X POST
     "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e",
     "updatedAt": 1574730504762,
     "status": "RUNNING",
-    "taskArn": "arn:aws:ecs:us-east-1:111111111111123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a"
+    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a"
 }
 ```
 
@@ -554,7 +554,7 @@ curl -X POST
     "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e",
     "operationType": "Bulk Granule Reingest",
     "status": "RUNNING",
-    "taskArn": "arn:aws:ecs:us-east-1:111111111111123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a",
+    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a",
     "updatedAt": 1574730504762
 }
 ```

--- a/content/granules.md
+++ b/content/granules.md
@@ -115,7 +115,7 @@ $ curl https://example.com/granules/MOD11A1.A2017137.h20v17.006.2017138085755 --
     "collectionId": "MOD11A1___006",
     "status": "completed",
     "provider": "LP_TS2_DataPool",
-    "execution": "https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:433612427488123456789012:execution:LpdaacCumulusIngestGranuleStateMachine-N3CLGBXRPAT9:7f071dae1a93c9892272b7fd5",
+    "execution": "https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789012:execution:LpdaacCumulusIngestGranuleStateMachine-N3CLGBXRPAT9:7f071dae1a93c9892272b7fd5",
     "files": [
         {
             "bucket": "cumulus-devseed-protected",
@@ -487,8 +487,8 @@ Overview of the request fields:
 | `index` | `yes` - if `query` is present | `string` | Elasticsearch index to search with the given query |
 
 
-An optional data parameter of `executionArn` is also available to allow you to override the input message to the reingest. If `executionArn` is specified, the original message is pulled directly
-from that execution and used in reingest.
+An optional data parameter of `workflowName` is also available to allow you to override the input message to the reingest. If `workflowName` is specified, the original message is pulled directly
+by finding the most recent execution of the workflowName assocated with the granuleId.
 
 
 ```endpoint
@@ -533,15 +533,15 @@ $ curl --request POST \
     }'
 ```
 
-#### Example request with given Granule IDs and executionArn optional parameter:
+#### Example request with given Granule IDs and optional workflow parameter:
 
 ```curl
 curl -X POST
   https://example.com/granules/bulkReingest
   --header 'Authorization: Bearer ReplaceWithTheToken' --header 'Content-Type: application/json'
-   --data '{
+  --data '{
         "ids": ["MOD09GQ.A2016358.h13v04.006.2016360104606"],
-        "executionArn": "arn:aws:states:us-east-1:1234567890123456789012:execution:stack-lambdaName:9da47a3b-4d85-4599-ae78-dbec2e042520",
+        "workflow": "workflowName",
         }'
 ```
 


### PR DESCRIPTION
Documentation for Cumulus-2463.

Examples on how to use workflowName and executionArn as data parameters to the granules/{granuleId} with reingest action, as well as granules/BulkReingest workflowName example update.