### PR TITLE
CUMULUS-2939:Update response for granules/bulk* and reconciliationReports post endpoints

### DIFF
--- a/api-client-py/requirements.txt
+++ b/api-client-py/requirements.txt
@@ -1,2 +1,2 @@
 future
-requests==2.20.1
+requests==2.27.1

--- a/content/granules.md
+++ b/content/granules.md
@@ -557,11 +557,7 @@ curl -X POST
 
 ```json
 {
-    "createdAt": 1574730504000,
-    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e",
-    "updatedAt": 1574730504762,
-    "status": "RUNNING",
-    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a"
+    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e"
 }
 ```
 
@@ -634,11 +630,7 @@ curl -X POST
 
 ```json
 {
-    "createdAt": 1574730504000,
-    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e",
-    "updatedAt": 1574730504762,
-    "status": "RUNNING",
-    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a"
+    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e"
 }
 ```
 
@@ -720,13 +712,7 @@ curl -X POST
 
 ```json
 {
-    "createdAt": 1574730504000,
-    "description": "Bulk granule reingest run on 2 granules",
-    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e",
-    "operationType": "Bulk Granule Reingest",
-    "status": "RUNNING",
-    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/d481e76e-f5fc-9c1c-2411-fa13779b111a",
-    "updatedAt": 1574730504762
+    "id": "0eb8e809-8790-5409-1239-bcd9e8d28b8e"
 }
 ```
 

--- a/content/reconciliation-reports.md
+++ b/content/reconciliation-reports.md
@@ -631,13 +631,7 @@ $ curl --request POST https://example.com/reconciliationReports --header 'Author
 
 ```json
 {
-  "createdAt": 1623256106616,
-  "updatedAt": 1623256106616,
-  "id": "bb7059f4-0cd8-4205-8857-fb0e6b68b3e4",
-  "status": "RUNNING",
-  "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/stackname-CumulusECSCluster/656b2c8203c4488e9feffff38beb4be5",
-  "description": "Create Reconciliation Report",
-  "operationType": "Reconciliation Report"
+  "id": "bb7059f4-0cd8-4205-8857-fb0e6b68b3e4"
 }
 ```
 


### PR DESCRIPTION
1. Update example responses for granules/bulk* and reconciliationReports post endpoints
2. update api-client-py/requirements.txt requests==2.27.1 to fix snyk error